### PR TITLE
Handle intentionally empty grpc BestOptions

### DIFF
--- a/cluster-autoscaler/expander/grpcplugin/grpc_client.go
+++ b/cluster-autoscaler/expander/grpcplugin/grpc_client.go
@@ -92,9 +92,9 @@ func (g *grpcclientstrategy) BestOptions(expansionOptions []expander.Option, nod
 		return expansionOptions
 	}
 
-	if bestOptionsResponse == nil || bestOptionsResponse.Options == nil {
-		klog.V(4).Info("GRPC returned nil bestOptions, no options filtered")
-		return expansionOptions
+	if bestOptionsResponse == nil || len(bestOptionsResponse.Options) == 0 {
+		klog.V(4).Info("GRPC returned nil bestOptions")
+		return nil
 	}
 	// Transform back options slice
 	options := transformAndSanitizeOptionsFromGRPC(bestOptionsResponse.Options, nodeGroupIDOptionMap)


### PR DESCRIPTION
## Problem
When trying to filter out all options from the gRPC expander side, I noticed that the gRPC expander client on cluster autoscaler would return all the expansion options, rather than none of them.

This is a problem because in some cases I want to filter out all options on the gRPC expander server side, however the cluster-autoscaler client is unfiltering the options when the server returns nothing. 

I would expect that if the gRPC expander server returns no best options, CA should fail its scaleup since it has no options available.

## Current Behaviour

In the case of nil best options returned from the gRPC expander, the gRPC client returns all original options https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/expander/grpcplugin/grpc_client.go#L95-L98

## Proposed Change

If the grpc expander server returns nil, the client should respect that and also return nil. This is similar to what other expanders do https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/expander/waste/waste.go#L67-L69

This change does break things for users who rely on a nil response from the grpc expander server, however this behaviour is very unexpected and I believe it should change to be more predictable

If users want the original behaviour where the client ends up returning all original options, then on the gRPC expander server side they can return an error. Then expander will apply no filtering and return the original expansionOptions.

When the scaleup orchestrator gets an empty best option, it will fail the scaleup as expected https://github.com/rrangith/autoscaler/blob/721ea01f7f284484fa491ae89e08bded434bcd46/cluster-autoscaler/core/scaleup/orchestrator/orchestrator.go#L178-L185


